### PR TITLE
Précise la graphie du mot Etalab (closes etalab/etalab#6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Livret de bienvenue — Etalab
 
+## Sections
+
 * [Bienvenue à Etalab](bienvenue.md)
+* [Nos rituels](nos-rituels.md)
+* [Typographie](typographie.md)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# Etalab
+# Livret de bienvenue — Etalab
 
 * [Bienvenue à Etalab](bienvenue.md)

--- a/bienvenue.md
+++ b/bienvenue.md
@@ -1,113 +1,81 @@
-# Bienvenue à Etalab
+# Bienvenue
 
-## Bien démarrer
+Bienvenue au sein de la mission Etalab. Voici quelques conseils pour bien démarrer.
 
-### Récupérer un badge
+## Récupérer un badge
 
-Pour obtenir le badge qui permet d’accéder au bâtiment du [20 avenue de Ségur](https://adresse.data.gouv.fr/map?lng=2.30831&lat=48.8503&z=18), voici la marche à suivre :
+Pour obtenir le badge qui permet d’accéder au bâtiment du [20 avenue de Ségur](https://adresse.data.gouv.fr/map?lng=2.30831&lat=48.8503&z=18), voici la marche à suivre&nbsp;:
 
-1. Imprimer et remplir le [formulaire de demande de badge](https://raw.github.com/wiki/betagouv/beta.gouv.fr/files/formulaire.pdf).
-2. Faire valider le formulaire par le responsable hiérarchique
-3. Transmettre le formulaire au secrétariat
+1. Imprimer et remplir le [formulaire de demande de badge](https://raw.github.com/wiki/betagouv/beta.gouv.fr/files/formulaire.pdf)&nbsp;;
+2. Faire valider le formulaire par le responsable hiérarchique&nbsp;;
+3. Transmettre le formulaire au secrétariat.
 
-### Obtenir une adresse e-mail
+## Obtenir une adresse e-mail
 
-Les agents contractuels peuvent disposer de deux adresses e-mail :
+Les agents contractuels peuvent disposer de deux adresses e-mail&nbsp;:
 
-1. Une adresse @modernisation.gouv : `prenom.nom@modernisation.gouv.fr` ;
-2. Une adresse @data.gouv : `prenom.nom@data.gouv.fr`
+1. Une adresse @modernisation.gouv.fr&nbsp;: `prenom.nom@modernisation.gouv.fr`&nbsp;;
+2. Une adresse @data.gouv.fr&nbsp;: `prenom.nom@data.gouv.fr`
 
 Les prestataires peuvent demander une adresse e-mail en `@data.gouv.fr`.
 
 Pour obtenir une adresse se terminant par `@modernisation.gouv.fr`, il faut se renseigner auprès du service informatique en appelant le 01 53 18 80 00.
 
-Pour obtenir une adresse se terminant par `@data.gouv.fr`, il faut se renseigner auprès de l’équipe etalab : Paul-Antoine Chevalier, Christian Quest ou Vincent Bataille. On peut consulter les mails en datagouv sur le [webmail](https://webmail.data.gouv.fr).
+Pour obtenir une adresse se terminant par `@data.gouv.fr`, il faut se renseigner auprès de l’équipe etalab&nbsp;: Paul-Antoine Chevalier, Christian Quest ou Vincent Bataille. On peut consulter les mails en datagouv sur le [webmail](https://webmail.data.gouv.fr).
 
-### Créer un compte Slack
+## Créer un compte Slack
 
-Pour communiquer en interne au quotidien, nous utilisons Slack, une messagerie instantanée : https://startups-detat.slack.com/. Ce compte Slack est partagé entre Etalab et l’[incubateur de services numériques](https://beta.gouv.fr/).
+Pour communiquer en interne au quotidien, nous utilisons Slack, une messagerie instantanée&nbsp;: https://startups-detat.slack.com/. Ce compte Slack est partagé entre Etalab et l’[incubateur de services numériques](https://beta.gouv.fr/).
 
 Pour être valide, l’inscription sur le compte Slack doit être faite avec une adresse de travail se terminant par `@modernisation.gouv` ou `@data.gouv.fr`.
 
-Bon à savoir :
+Bon à savoir&nbsp;:
 
-* les canaux etalab commencent par le préfixe `etalab_` ;
-* le canal 🔒[#domaine_opendata](https://startups-detat.slack.com/messages/C04QZ3S8H) nous concerne aussi ;
+* les canaux etalab commencent par le préfixe `etalab_`&nbsp;;
+* le canal 🔒[#domaine_opendata](https://startups-detat.slack.com/messages/C04QZ3S8H) nous concerne aussi&nbsp;;
 * la commande `/trad` permet de traduire certains acronymes. Exemple `/trad DINSIC`.
 
 [Lire la documentation de beta.gouv sur Slack](https://github.com/betagouv/beta.gouv.fr/wiki/Slack)
-
-## Les rituels du service au quotidien
-
-### Pour l’équipe etalab  
-
-Trois rendez-vous hebdomadaires :
-
-1. La réunion d’équipe etalab : mardi à 11 h 30 dans le grand open-space ;
-2. Le [Fridaylab](etalab/fridaylab) : vendredi de 14 h 00 à 17 h 00 ;
-3. Le Star Club : lundi à 10 h 30 dans bureau de Laure (réunion réservée aux responsables de pôle).
-
-### Pour l’équipe [data.gouv](https://www.data.gouv.fr/fr/)
-
-Réunion data.gouv le lundi à 15 h 00.
-
-### Pour l’équipe openfisca
-
-Démo [openfisca](https://fr.openfisca.org/) un mercredi sur deux, à 10 h 00 en salle canapé.
-
-### Pour l’équipe EIG
-
-Deux rendez-vous :
-
- 1. Le stand-up hebdomadaire, le mardi à 14 h 30 ;
- 2. Les sessions d’accompagnement des EIG 2 fois par mois. [Voir le programme d’accompagnement](https://github.com/entrepreneur-interet-general/eig-link/blob/master/accompagnement.org).
-
-### Ailleurs à la DINSIC
-
-Le [stand-up de l’incubateur](https://github.com/betagouv/beta.gouv.fr/wiki/Standup), tous les mercredi à 12 h 00.
 
 ## Les canaux de communication
 
 ### Blogs
 
-Les blogs à suivre :
+Les blogs à suivre&nbsp;:
 
-* le [blog d’etalab](http://etalab.gouv.fr/) ;
-* le [blog de l’AGD](https://agd.data.gouv.fr/) ;
-* le [blog EIG](https://entrepreneur-interet-general.etalab.gouv.fr/blog.html) :
+* le [blog d’etalab](http://etalab.gouv.fr/)&nbsp;;
+* le [blog de l’AGD](https://agd.data.gouv.fr/)&nbsp;;
+* le [blog EIG](https://entrepreneur-interet-general.etalab.gouv.fr/blog.html)&nbsp;:
 * le [blog Géo](https://blog.geo.data.gouv.fr).
 
 ### Réseaux sociaux
 
-Deux comptes Twitter à suivre :
+Deux comptes Twitter à suivre&nbsp;:
 
-1. [@etalab](https://twitter.com/etalab) ;
+1. [@etalab](https://twitter.com/etalab)&nbsp;;
 2. [@datagouvfr](https://twitter.com/datagouvfr).
 
-Les comptes Twitter associés aux verticales d’etalab :
+Les comptes Twitter associés aux verticales d’etalab&nbsp;:
 
-* [@geodatagouv](https://twitter.com/geodatagouv) ;
-* [@adressedatagouv](https://twitter.com/adressedatagouv) ;
+* [@geodatagouv](https://twitter.com/geodatagouv)&nbsp;;
+* [@adressedatagouv](https://twitter.com/adressedatagouv)&nbsp;;
 * [@APIGouv](https://twitter.com/APIGouv).
 
 La [page Facebook d’Etalab](https://www.facebook.com/etalab/).
 
 ### GitHub
 
-Pour le code source, nous utilisons Github, où nous avons plusieurs équipes :
+Pour le code source, nous utilisons Github, où nous avons plusieurs équipes&nbsp;:
 
-* [Etalab](https://github.com/etalab) ;
-* [SGMAP-AGD](https://github.com/sgmap-agd) ;
-* [Geodatagouv](https://github.com/geodatagouv) ;
-* [EIG](https://github.com/entrepreneur-interet-general) ;
-* [Open Data Team](https://github.com/opendatateam) ;
+* [Etalab](https://github.com/etalab)&nbsp;;
+* [SGMAP-AGD](https://github.com/sgmap-agd)&nbsp;;
+* [Geodatagouv](https://github.com/geodatagouv)&nbsp;;
+* [EIG](https://github.com/entrepreneur-interet-general)&nbsp;;
+* [Open Data Team](https://github.com/opendatateam)&nbsp;;
 * [Addok](https://github.com/addok).
 
 ### Nos autres outils
 
-* [Nextcloud](https://nextcloud.data.gouv.fr), pour le partage de fichiers.
-* [Trello](https://trello.com/etalab/home), pour le suivi de projet.
-
-## En savoir plus sur la DINSIC
-
-* Consulter le [wiki de la DINSIC](https://dinsic.xwiki.com/)
+* [Nextcloud](https://nextcloud.data.gouv.fr), pour le partage de fichiers&nbsp;;
+* [Trello](https://trello.com/etalab/home), pour le suivi de projet&nbsp;;
+* le [wiki de la DINSIC](https://dinsic.xwiki.com/), pour l’intranet.

--- a/bienvenue.md
+++ b/bienvenue.md
@@ -44,11 +44,14 @@ Bon à savoir&nbsp;:
 Les blogs à suivre&nbsp;:
 
 * le [blog d’etalab](http://etalab.gouv.fr/)&nbsp;;
+* le [blog de data.gouv.fr](https://www.data.gouv.fr/fr/posts/)&nbsp;;
 * le [blog de l’AGD](https://agd.data.gouv.fr/)&nbsp;;
 * le [blog EIG](https://entrepreneur-interet-general.etalab.gouv.fr/blog.html)&nbsp;:
 * le [blog Géo](https://blog.geo.data.gouv.fr).
 
 ### Réseaux sociaux
+
+#### Twitter
 
 Deux comptes Twitter à suivre&nbsp;:
 
@@ -59,7 +62,10 @@ Les comptes Twitter associés aux verticales d’etalab&nbsp;:
 
 * [@geodatagouv](https://twitter.com/geodatagouv)&nbsp;;
 * [@adressedatagouv](https://twitter.com/adressedatagouv)&nbsp;;
-* [@APIGouv](https://twitter.com/APIGouv).
+* [@APIGouv](https://twitter.com/APIGouv)&nbsp;;
+* [@eigforever](https://twitter.com/eigforever).
+
+#### Facebook
 
 La [page Facebook d’Etalab](https://www.facebook.com/etalab/).
 

--- a/nos-rituels.md
+++ b/nos-rituels.md
@@ -1,0 +1,28 @@
+# Les rituels du service au quotidien
+
+## Pour l’équipe etalab  
+
+Trois rendez-vous hebdomadaires&nbsp;:
+
+1. La réunion d’équipe etalab&nbsp;: mardi à 11&nbsp;h&nbsp;30 dans le grand open-space&nbsp;;
+2. Le [Fridaylab](etalab/fridaylab)&nbsp;: vendredi de 14 h 00 à 17&nbsp;h&nbsp;00&nbsp;;
+3. Le Star Club&nbsp;: lundi à 10&nbsp;h&nbsp;30 dans bureau de Laure (réunion réservée aux responsables de pôle).
+
+## Pour l’équipe [data.gouv.fr](https://www.data.gouv.fr/fr/)
+
+Réunion data.gouv.fr le lundi à 15&nbsp;h&nbsp;00.
+
+## Pour l’équipe Open Fisca
+
+Démo [openfisca](https://fr.openfisca.org/) un mercredi sur deux, à 10&nbsp;h&nbsp;00 en salle canapé.
+
+## Pour l’équipe EIG
+
+Deux rendez-vous&nbsp;:
+
+ 1. Le stand-up hebdomadaire, le mardi à 14 h 30&nbsp;;
+ 2. Les sessions d’accompagnement des EIG 2 fois par mois. [Voir le programme d’accompagnement](https://github.com/entrepreneur-interet-general/eig-link/blob/master/accompagnement.org).
+
+## Ailleurs à la DINSIC
+
+Le [stand-up de l’incubateur](https://github.com/betagouv/beta.gouv.fr/wiki/Standup), tous les mercredi à 12&nbsp;h&nbsp;00.

--- a/typographie.md
+++ b/typographie.md
@@ -6,5 +6,5 @@ Dans la grande majorité des cas, nous suivons les [règles typographiques en us
 
 Contrairement à la DINSIC (Direction interministérielle du numérique et du système d'information et de communication de l'État), Etalab n’est pas un sigle, mais [un nom de mission](https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000023619063&categorieLien=id), un nom propre. Comme le `E-` initial d’Etalab ne renvoie pas au mot `État`, il ne prend jamais d’accent aigu.
 
-* Ne pas écrire : La mission _Étalab_ a été fondée en 2011.
-* Écrire : La mission _Etalab_ (ou _etalab_)a été fondée en 2011.
+* **Ne pas écrire** : La mission _Étalab_ a été fondée en 2011.
+* **Écrire** : La mission _Etalab_ (ou _etalab_)a été fondée en 2011.

--- a/typographie.md
+++ b/typographie.md
@@ -1,0 +1,10 @@
+# Typographie
+
+Dans la grande majorité des cas, nous suivons les [règles typographiques en usage à l’Imprimerie nationale](https://catalogue.bnf.fr/ark:/12148/cb38887921n.public). Les cas spécifiques à Etalab sont présentés sur cette page.
+
+## Graphie d’Etalab
+
+Contrairement à la DINSIC (Direction interministérielle du numérique et du système d'information et de communication de l'État), Etalab n’est pas un sigle, mais [un nom de mission](https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000023619063&categorieLien=id), un nom propre. Comme le `E-` initial d’Etalab ne renvoie pas au mot `État`, il ne prend jamais d’accent aigu.
+
+* Ne pas écrire : La mission _Étalab_ a été fondée en 2011.
+* Écrire : La mission _Etalab_ (ou _etalab_)a été fondée en 2011.


### PR DESCRIPTION
Cette _pull-request_ fait deux choses :

1. Elle ajoute, dans le livret de bienvenue, une page consacrée à la typographique, page qui ne parle pour l’instant que de la graphie du mot « Etalab » (ce qui ferme #6).
2. Elle sort la partie consacrée aux rituels du fichier `bienvenue.md` pour la mettre dans une page spécifique (`nos-rituels.md`).