### PR TITLE
Remplace le FramaCalc par un FramaForm

### DIFF
--- a/guide-des-deplacements.md
+++ b/guide-des-deplacements.md
@@ -6,7 +6,7 @@ Cette page contient la liste des choses à faire avant, pendant, et après un d�
 
 ### À faire avant de partir
 
-Indiquez dans [ce tableau ouvert](https://lite.framacalc.org/cooperationinternationalenum) le déplacement auquel vous prenez part, ou la coopération internationale sur laquelle vous travaillez&nbsp;— même si cette coopération n’en est encore qu’au stade de la discussion.
+Avant de partir, [remplissez ce formulaire](https://framaforms.org/preparation-des-deplacements-a-letranger-1538035632) en y indiquant le déplacement auquel vous prenez part, ou la coopération internationale sur laquelle vous travaillez&nbsp;— même si cette coopération n’en est encore qu’au stade de la discussion.
 
 ### À faire à votre retour
 

--- a/nos-rituels.md
+++ b/nos-rituels.md
@@ -4,9 +4,9 @@
 
 Trois rendez-vous hebdomadaires&nbsp;:
 
-1. La réunion d’équipe etalab&nbsp;: mardi à 11&nbsp;h&nbsp;30 dans le grand open-space&nbsp;;
+1. La réunion d’équipe Etalab&nbsp;: mardi à 11&nbsp;h&nbsp;30 dans le grand open-space&nbsp;;
 2. Le [Fridaylab](etalab/fridaylab)&nbsp;: vendredi de 14 h 00 à 17&nbsp;h&nbsp;00&nbsp;;
-3. Le Star Club&nbsp;: lundi à 10&nbsp;h&nbsp;30 dans bureau de Laure (réunion réservée aux responsables de pôle).
+3. Le point hebdomadaire : lundi à 10&nbsp;h&nbsp;30 dans bureau de Laure (réunion réservée aux responsables de pôle).
 
 ## Pour l’équipe [data.gouv.fr](https://www.data.gouv.fr/fr/)
 


### PR DESCRIPTION
Cette _pull request_ remplace le FramaCalc des déplacements à l’étranger par [un FramaForm](https://framaforms.org/preparation-des-deplacements-a-letranger-1538035632) qui fait exactement la même chose. Elle change aussi le nom d’une réunion.