### PR TITLE
Ajoute la liste des évènements passés

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ## Sections
 
-* [Bienvenue à Etalab](bienvenue.md)
-* [Guide des déplacements](guide-des-deplacements.md)
-* [Nos bureaux](nos-bureaux.md)
-* [Nos rituels](nos-rituels.md)
-* [Typographie](typographie.md)
-* [Présentations](presentations.md)
-
+- [Bienvenue à Etalab](bienvenue.md)
+- [Guide des déplacements](guide-des-deplacements.md)
+- [Nos bureaux](nos-bureaux.md)
+- [Nos rituels](nos-rituels.md)
+- [Règles typographiques](typographie.md)
+- [Présentations et diaporamas](presentations.md)
+- [Liste des évènements passés](evenements.md)

--- a/evenements.md
+++ b/evenements.md
@@ -1,0 +1,55 @@
+# Liste des évènements organisés par Etalab
+
+Cette page regroupe les évènements publics organisés par Etalab.
+
+## 2018
+
+| Date       | Évènement                                             | Lieu                      | URL                                                                                                                                                                         |
+| ---------- | ----------------------------------------------------- | ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 12/10/2018 | Atelier : plateforme data.gouv.fr                     | Fondation Mozilla (Paris) | [Voir sur Eventbrite](https://www.eventbrite.com/e/billets-atelier-plateforme-datagouvfr-50867012604#)                                                                      |
+| 11/10/2018 | Atelier : de la donnée ouverte à l'information        | La Paillasse              | [Voir sur Eventbrite](https://www.eventbrite.com/e/billets-atelier-de-la-donnee-ouverte-a-linformation-50867174087#)                                                        |
+| 10/10/2018 | Soirée Open Data par principe                         | Fondation Mozilla (Paris) | [Voir sur Eventbrite](https://www.eventbrite.com/e/billets-soiree-open-data-par-principe-51006845849)                                                                       |
+| 08/10/2018 | Atelier: Elargissons le service public de la donnée   | Liberte Living-Lab        | [Voir sur Eventbrite](https://www.eventbrite.com/e/billets-atelier-elargissons-le-service-public-de-la-donnee-50866855133#)                                                 |
+| 03/10/2018 | Présentation EIG 3                                    | Liberté Living-lab        | [Voir sur Facebook](https://www.facebook.com/events/1911979112179067/)                                                                                                      |
+| 19/09/2018 | Projection-débat #DataGueule _Démocratie(s) ?_        | Liberté Living-lab        | [Voir sur Facebook](https://www.facebook.com/events/306250383520959/)                                                                                                       |
+| 13/09/2018 | Forum Open d'Etat #4 : Transparence des algorithmes   | Nantes                    | [Voir sur Eventbrite](https://www.eventbrite.fr/e/billets-forum-open-detat-4-transparence-des-algorithmes-et-mediation-autour-des-donnees-48156645824#)                     |
+| 09/07/2018 | Forum Open d'Etat #3 : Ouvrons la science !           | Toulouse                  | [Voir sur Eventbrite](https://www.eventbrite.fr/e/billets-forum-open-detat-3-ouvrons-la-science-47212723527#)                                                               |
+| 24/05/2018 | Forum Open d'Etat #2 : Intégrité de l'action publique | HATVP                     | [Voir sur Eventbrite](https://www.eventbrite.fr/e/billets-forum-open-detat-2-integrite-de-laction-publique-comprendre-les-donnees-du-repertoire-numerique-des-45762827850#) |
+| 15/05/2018 | Appel à projets EIG 3                                 | Liberte Living Lab        | [Voir sur Eventbrite](https://www.eventbrite.fr/e/billets-reunion-dinformation-appel-a-projets-entrepreneure-dinteret-general-promotion-3-45716310716#)                     |
+
+## 2017
+
+À compléter
+
+## 2016
+
+| Date       | Évènement                                      | Lieu                              | URL                                                                                                                   |
+| ---------- | ---------------------------------------------- | --------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| 07/12/2016 | Open Government Partnership Global Summit      | Paris                             | [Voir sur Facebook](https://www.facebook.com/events/241036296261017/)                                                 |
+| 18/11/2016 | Présentation programme EIG                     | La Gaîté Lyrique                  | [Voir sur Facebook](https://www.facebook.com/events/354348118259235/)                                                 |
+| 10/09/2016 | Open Asso                                      | Sens Espace                       | [Voir sur Facebook](https://www.facebook.com/events/776973225777737/)                                                 |
+| 18/03/2018 | Atelier ouvert : traduction de logiciels       | Mutinerie                         | [Voir sur Eventbrite](https://www.eventbrite.fr/e/billets-atelier-ouvert-etalab-traduction-de-logiciels-22728856622#) |
+| 26/02/2018 | Atelier ouvert : forum.etalab.gouv.fr          | Mutinerie                         | [Voir sur Eventbrite](https://www.eventbrite.fr/e/billets-atelier-ouvert-forumetalabgouvfr-21492230841#)              |
+| 19/02/2018 | #HackFrancophonie                              | NUMA                              | [Voir sur Eventbrite](https://www.eventbrite.fr/e/billets-hackfrancophonie-20421875379#)                              |
+| 02/02/2016 | Concours Dataconnexions #6: Finale & cérémonie | Hôtel de la métropole de Toulouse | [Voir sur Eventbrite](https://www.eventbrite.fr/e/billets-concours-dataconnexions-6-finale-ceremonie-19573273187#)    |
+
+## 2015
+
+| Date       | Évènement                                            | Lieu                        | URL                                                                                                                     |
+| ---------- | ---------------------------------------------------- | --------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| 17/10/2015 | Open Data Camp : la vie quotienne en données         | AntiCafé Innovation Factory | [Voir sur Eventbrite](https://www.eventbrite.fr/e/billets-open-data-camp-la-vie-quotienne-en-donnees-18610553667#)      |
+| 16/10/2015 | Conférence : L'impact social de la donnée            | AntiCafé Innovation Factory | [Voir sur Eventbrite](https://www.eventbrite.fr/e/billets-conference-limpact-social-de-la-donnee-18668658460#)          |
+| 02/10/2015 | Hackathon allocations familiales                     | Les Docks de Paris          | [Voir sur Facebook](https://www.facebook.com/events/790007911122308/)                                                   |
+| 20/05/2015 | Open Data Camp sur les données de la douane          | Cap Digital                 | [Voir sur Eventbrite](https://www.eventbrite.fr/e/open-data-camp-sur-les-donnees-de-la-douane-tickets-16764813007#)     |
+| 17/03/2015 | Point d'étape #4 : Plan d'action Gouvernement Ouvert | NUMA                        | [Voir sur Eventbrite](https://www.eventbrite.fr/e/billets-point-detape-4-plan-daction-gouvernement-ouvert-14892994347#) |
+| 17/02/2015 | Point d'étape #3 : Plan d'action Gouvernement Ouvert | SUPERPUBLIC                 | [Voir sur Eventbrite](https://www.eventbrite.fr/e/billets-point-detape-3-plan-daction-gouvernement-ouvert-14892848912#) |
+| 05/02/2015 | Concours Dataconnexions #5 : Finale & Cérémonie      | Palais du Luxembourg        | [Voir sur Eventbrite](https://www.eventbrite.fr/e/billets-concours-dataconnexions-5-finale-ceremonie-15174676867#)      |
+| 26/05/2015 | Hackathon DAMIR - Assurance Maladie                  | La Paillasse                | [Voir sur Eventbrite](https://www.eventbrite.fr/e/billets-hackathon-damir-assurance-maladie-etalab-14989462887#)        |
+
+## 2014
+
+| Date       | Évènement                                            | Lieu          | URL                                                                                                                                             |
+| ---------- | ---------------------------------------------------- | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| 16/10/2014 | Point d'étape #1 : Plan d'action Gouvernement Ouvert | NUMA          | [Voir sur Eventbrite](https://www.eventbrite.fr/e/billets-point-detape-1-elaboration-du-plan-daction-national-gouvernement-ouvert-14892806786#) |
+| 15/11/2018 | Atelier OpenGov                                      | Le Centquatre | [Voir sur Eventbrite](https://www.eventbrite.fr/e/atelier-opengov-lors-de-la-semaine-de-linnovation-publique-tickets-14216571147#)              |
+| 14/11/2018 | Open Data Camps: et après ?                          | Le Centquatre | [Voir sur Eventbrite](https://www.eventbrite.fr/e/billets-open-data-camps-et-apres-open-data-camps-et-apres-13752216249#)                       |

--- a/typographie.md
+++ b/typographie.md
@@ -6,8 +6,8 @@ Dans la grande majorité des cas, nous suivons les [règles typographiques en us
 
 Contrairement à la DINSIC (Direction interministérielle du numérique et du système d'information et de communication de l'État), Etalab n’est pas un sigle mais [un nom de mission](https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000023619063&categorieLien=id), un nom propre. Comme le `E-` initial d’Etalab ne renvoie pas au mot `État`, il ne prend jamais d’accent aigu.
 
-* **Ne pas écrire** : La mission _Étalab_ a été fondée en 2011.
-* **Écrire** : La mission _Etalab_ (ou _etalab_) a été fondée en 2011.
+- **Ne pas écrire** : La mission _Étalab_ a été fondée en 2011.
+- **Écrire** : La mission _Etalab_ (ou _etalab_) a été fondée en 2011.
 
 ## Ponctuation des listes
 
@@ -15,35 +15,47 @@ Les éléments qui composent une liste sont précédés par un numéro, un tiret
 
 ### 1. Liste introduite par le signe deux-points (`:`)
 
-Les éléments d’une liste introduite par le signe _deux-points_ (`:`) ne prennent pas de majuscule s’ils ne sont pas ordonnés, c’est-à-dire s’ils ne sont pas précédés de chiffres. Chaque élément d’une telle liste se termine par un point-virgule (`;`), précédé par une espace insécable (` `), sauf le dernier élément qui se termine par un point final (`.`).
+Les éléments d’une liste introduite par le signe _deux-points_ (`:`) ne prennent pas de majuscule s’ils ne sont pas ordonnés, c’est-à-dire s’ils ne sont pas précédés de chiffres. Chaque élément d’une telle liste se termine par un point-virgule (`;`), précédé par une espace insécable, sauf le dernier élément qui se termine par un point final (`.`).
 
+```
 Exemple de liste introduite par le deux-points :
-- premier élément ;
-- deuxième élément ;
-- dernier élément.
+
+– premier élément ;
+– deuxième élément ;
+– dernier élément.
+```
 
 **Cas particulier**
 Si les éléments de la liste sont ordonnés, c’est-à-dire s’ils commencent par un chiffre, alors chaque élément commence par une majuscule et se termine par un point-virgule ou un point final (selon sa position dans la liste).
 
+```
 Exemple de liste introduite par le deux-points :
+
 1. Premier élément ;
 2. Deuxième élément ;
 3. Dernier élément.
+```
 
 ### 2. Liste introduite par rien du tout
 
 Si une liste n’est pas introduite par le signe _deux-points_ (`:`), alors ses éléments commencent par une majuscule mais ne prennent pas de ponctuation à leur terme.
 
+```
 Exemple de liste introduite par rien du tout
-- Premier élément
-- Deuxième élément
-- Dernier élément
+
+– Premier élément
+– Deuxième élément
+– Dernier élément
+```
 
 ### 3. Liste de phrases complètes sans signe introductif
 
 Si les éléments d’une liste sont des phrases complètes, et que cette liste n’est pas introduite par le signe _deux-points_ (`:`), alors chaque élément commence par une liste et se termine par un point — comme une phrase ordinaire.
 
+```
 Voici un exemple
-- Ceci est la première phrase.
-- Ceci est la deuxième phrase.
-- Ceci est la dernière phrase.
+
+– Ceci est la première phrase.
+– Ceci est la deuxième phrase.
+– Ceci est la dernière phrase.
+```


### PR DESCRIPTION
Closes #19.

Cette _pull request_ ajoute la liste des évènements publics organisés par Etalab au cours des années précédentes. La liste est encore loin d’être complète. Voici les sources utilisées pour créer la première version de cette liste :

- notre page Facebook : https://www.facebook.com/pg/etalab/events/ ;
- notre premier compte Eventbrite : https://www.eventbrite.fr/o/etalab-6144358529 ;
- notre second (🤷‍♂️) compte Eventbrite : https://www.eventbrite.com/o/etalab-17920410880.

Cette _pull request_ apporte aussi des ajustements typographiques mineurs. 🔎 